### PR TITLE
Disable load_system_host_keys

### DIFF
--- a/hermes/manager.py
+++ b/hermes/manager.py
@@ -98,7 +98,6 @@ class Manager(object):
             key_filename = None
 
         self.ssh_client = SSHClient()
-        self.ssh_client.load_system_host_keys()
         self.ssh_client.set_missing_host_key_policy(IgnorePolicy())
         self.ssh_client.connect(
             self.dns_name,


### PR DESCRIPTION
This causes a deadlock in Jenkins for some reason. It shouldn't be needed anyway, since we're ignoring unknown hosts.