### PR TITLE
Don't attempt to echo created secret ID

### DIFF
--- a/hermes_cli/commands/secrets.py
+++ b/hermes_cli/commands/secrets.py
@@ -40,11 +40,9 @@ def create(ctx, swarm_name, secret_name, secret_file, no_backup):
                 ACL='private',
                 Body=secret_data,
             )
-        click.echo(
-            manager.docker.secrets.create(
-                name=secret_name,
-                data=secret_data,
-            )
+        manager.docker.secrets.create(
+            name=secret_name,
+            data=secret_data,
         )
 
 @secrets.command()


### PR DESCRIPTION
It doesn't seem to work, probably a bug in docker-py but no time to
investigate now.